### PR TITLE
Erumble/refactor

### DIFF
--- a/live/services/helloworld/dev/main.tf
+++ b/live/services/helloworld/dev/main.tf
@@ -1,0 +1,8 @@
+module "helloworld" {  
+  source = "../../../../modules/terraform-aws-helloworld"
+
+  image_tag   = "1.0.0"
+  environment = "dev"
+  hosts       = ["helloworld.dev.examplr.co"]
+  deploy      = true
+}

--- a/live/services/helloworld/dev/providers.tf
+++ b/live/services/helloworld/dev/providers.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  # Configure credentials by setting env vars recognized by the AWS credential provider chain
+  # ex: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
+
+  default_tags {
+    tags = {
+      Environment = "Development"
+      ManagedBy   = "Terraform"
+      Project     = "HelloWorld"
+      Shared      = "true"
+    }
+  }
+}

--- a/live/services/helloworld/dev/state.tf
+++ b/live/services/helloworld/dev/state.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket         = "examplr-tfstate"
+    key            = "dev/ecs-helloworld.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "examplr-tfstate-lock"
+  }
+}

--- a/live/services/helloworld/dev/versions.tf
+++ b/live/services/helloworld/dev/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.61"
+    }
+  }
+}

--- a/live/services/helloworld/prod/main.tf
+++ b/live/services/helloworld/prod/main.tf
@@ -1,0 +1,8 @@
+module "helloworld" {  
+  source = "../../../../modules/terraform-aws-helloworld"
+
+  image_tag   = "1.0.0"
+  environment = "prod"
+  hosts       = ["api.examplr.co"]
+  deploy      = true
+}

--- a/live/services/helloworld/prod/providers.tf
+++ b/live/services/helloworld/prod/providers.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  # Configure credentials by setting env vars recognized by the AWS credential provider chain
+  # ex: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
+
+  default_tags {
+    tags = {
+      Environment = "Production"
+      ManagedBy   = "Terraform"
+      Project     = "HelloWorld"
+      Shared      = "true"
+    }
+  }
+}

--- a/live/services/helloworld/prod/state.tf
+++ b/live/services/helloworld/prod/state.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket         = "examplr-tfstate"
+    key            = "prod/ecs-helloworld.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "examplr-tfstate-lock"
+  }
+}

--- a/live/services/helloworld/prod/versions.tf
+++ b/live/services/helloworld/prod/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.61"
+    }
+  }
+}

--- a/live/shared/dev/main.tf
+++ b/live/shared/dev/main.tf
@@ -1,0 +1,13 @@
+module "dev_shared_infra" {
+  source = "../../../modules/terraform-aws-shared-infra"
+
+  alb_cert_domain_name = "dev.examplr.co."
+  alb_cert_sans        = ["*"]
+  environment          = "dev"
+  route53_domain_name  = "dev.examplr.co"
+  vpc_azs              = ["us-east-1a", "us-east-1c", "us-east-1d"]
+  vpc_cidr             = "10.24.0.0/16"
+  vpc_database_subnets = ["10.24.128.0/20", "10.24.144.0/20", "10.24.160.0/20"]
+  vpc_private_subnets  = ["10.24.32.0/19", "10.24.64.0/19", "10.24.96.0/19"]
+  vpc_public_subnets   = ["10.24.0.0/24", "10.24.1.0/24", "10.24.2.0/24"]
+}

--- a/live/shared/dev/main.tf
+++ b/live/shared/dev/main.tf
@@ -1,4 +1,4 @@
-module "dev_shared_infra" {
+module "shared_infra" {
   source = "../../../modules/terraform-aws-shared-infra"
 
   alb_cert_domain_name = "dev.examplr.co."

--- a/live/shared/dev/providers.tf
+++ b/live/shared/dev/providers.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  # Configure credentials by setting env vars recognized by the AWS credential provider chain
+  # ex: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
+
+  default_tags {
+    tags = {
+      Environment = "Development"
+      ManagedBy   = "Terraform"
+      Project     = "ECS"
+      Shared      = "true"
+    }
+  }
+}

--- a/live/shared/dev/state.tf
+++ b/live/shared/dev/state.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket         = "examplr-tfstate"
+    key            = "dev/ecs.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "examplr-tfstate-lock"
+  }
+}

--- a/live/shared/dev/versions.tf
+++ b/live/shared/dev/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.61"
+    }
+  }
+}

--- a/live/shared/prod/main.tf
+++ b/live/shared/prod/main.tf
@@ -1,0 +1,13 @@
+module "dev_shared_infra" {
+  source = "../../../modules/terraform-aws-shared-infra"
+
+  alb_cert_domain_name = "api.examplr.co."
+  alb_cert_sans        = ["*"]
+  environment          = "prod"
+  route53_domain_name  = "api.examplr.co"
+  vpc_azs              = ["us-east-1a", "us-east-1c", "us-east-1d"]
+  vpc_cidr             = "10.10.0.0/16"
+  vpc_database_subnets = ["10.10.128.0/20", "10.10.144.0/20", "10.10.160.0/20"]
+  vpc_private_subnets  = ["10.10.32.0/19", "10.10.64.0/19", "10.10.96.0/19"]
+  vpc_public_subnets   = ["10.10.0.0/24", "10.10.1.0/24", "10.10.2.0/24"]
+}

--- a/live/shared/prod/main.tf
+++ b/live/shared/prod/main.tf
@@ -1,4 +1,4 @@
-module "dev_shared_infra" {
+module "shared_infra" {
   source = "../../../modules/terraform-aws-shared-infra"
 
   alb_cert_domain_name = "api.examplr.co."

--- a/live/shared/prod/providers.tf
+++ b/live/shared/prod/providers.tf
@@ -1,0 +1,13 @@
+provider "aws" {
+  # Configure credentials by setting env vars recognized by the AWS credential provider chain
+  # ex: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION
+
+  default_tags {
+    tags = {
+      Environment = "Production"
+      ManagedBy   = "Terraform"
+      Project     = "ECS"
+      Shared      = "true"
+    }
+  }
+}

--- a/live/shared/prod/state.tf
+++ b/live/shared/prod/state.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket         = "examplr-tfstate"
+    key            = "prod/ecs.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "examplr-tfstate-lock"
+  }
+}

--- a/live/shared/prod/versions.tf
+++ b/live/shared/prod/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.61"
+    }
+  }
+}

--- a/modules/terraform-aws-alb-v2/acm.tf
+++ b/modules/terraform-aws-alb-v2/acm.tf
@@ -1,0 +1,41 @@
+resource "aws_acm_certificate" "alb" {
+  domain_name               = local.cert_domain_name
+  subject_alternative_names = length(local.cert_sans) > 0 ? local.cert_sans : null
+  validation_method         = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+
+    precondition {
+      condition     = endswith(local.cert_domain_name, var.route53_domain_name)
+      error_message = "The ACM cert domain name should be in the Route53 zone specified by var.route53_domain_name."
+    }
+
+    precondition {
+      condition     = length(local.cert_sans) > 0 ? alltrue([for san in local.cert_sans : endswith(san, var.route53_domain_name)]) : true
+      error_message = "All ACM cert subject alternative names should be in the Route53 zone specified by var.route53_domain_name."
+    }
+  }
+}
+
+resource "aws_route53_record" "alb_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.alb.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.domain.zone_id
+}
+
+resource "aws_acm_certificate_validation" "alb_validation" {
+  certificate_arn         = aws_acm_certificate.alb.arn
+  validation_record_fqdns = [for record in aws_route53_record.alb_validation : record.fqdn]
+}

--- a/modules/terraform-aws-alb-v2/alb.tf
+++ b/modules/terraform-aws-alb-v2/alb.tf
@@ -1,0 +1,42 @@
+resource "aws_lb" "this" {
+  name               = var.name
+  internal           = var.internal
+  load_balancer_type = "application"
+
+  subnets         = var.subnet_ids
+  security_groups = [aws_security_group.alb.id]
+}
+
+resource "aws_lb_listener" "ingress_80" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "ingress_443" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = aws_acm_certificate.alb.arn
+
+  default_action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Resource not found"
+      status_code  = "404"
+    }
+  }
+}

--- a/modules/terraform-aws-alb-v2/dns.tf
+++ b/modules/terraform-aws-alb-v2/dns.tf
@@ -1,0 +1,13 @@
+resource "aws_route53_record" "alb" {
+  for_each = toset(local.dns_records)
+
+  zone_id = data.aws_route53_zone.domain.zone_id
+  name    = each.value
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.this.dns_name
+    zone_id                = aws_lb.this.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/modules/terraform-aws-alb-v2/locals.tf
+++ b/modules/terraform-aws-alb-v2/locals.tf
@@ -1,0 +1,14 @@
+data "aws_route53_zone" "domain" {
+  name         = var.route53_domain_name
+  private_zone = var.route53_private_zone
+}
+
+locals {
+  # Using the same logic as creating a Route53 record, if we end the DNS record
+  # with a '.' keep it as is, otherwise append the domain name to the end of it.
+  cert_domain_name = endswith(var.cert_domain_name, ".") ? trimsuffix(var.cert_domain_name, ".") : format("%s.%s", var.cert_domain_name, var.route53_domain_name)
+  cert_sans        = distinct(compact([for san in var.cert_sans : endswith(san, ".") ? trimsuffix(san, ".") : format("%s.%s", san, var.route53_domain_name)]))
+  dns_records      = var.create_dns_records ? distinct(concat([local.cert_domain_name], local.cert_sans)) : []
+
+  security_group_rule_description = "This rule is managed by Terraform, do not change manually."
+}

--- a/modules/terraform-aws-alb-v2/outputs.tf
+++ b/modules/terraform-aws-alb-v2/outputs.tf
@@ -1,0 +1,32 @@
+output "arn" {
+  value = aws_lb.this.arn
+}
+
+output "id" {
+  value = aws_lb.this.id
+}
+
+output "listener" {
+  value = {
+    arn               = aws_lb_listener.ingress_443.arn
+    id                = aws_lb_listener.ingress_443.id
+    load_balancer_arn = aws_lb_listener.ingress_443.load_balancer_arn
+  }
+}
+
+output "name" {
+  value = aws_lb.this.name
+}
+
+output "security_group" {
+  value = {
+    arn      = aws_security_group.alb.arn
+    id       = aws_security_group.alb.id
+    owner_id = aws_security_group.alb.owner_id
+    vpd_id   = aws_security_group.alb.vpc_id
+  }
+}
+
+output "zone_id" {
+  value = aws_lb.this.zone_id
+}

--- a/modules/terraform-aws-alb-v2/security.tf
+++ b/modules/terraform-aws-alb-v2/security.tf
@@ -1,0 +1,41 @@
+resource "aws_security_group" "alb" {
+  description = "Security group ALB: ${var.name}"
+  name        = "ALB.${var.name}"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "egress" {
+  description       = local.security_group_rule_description
+  security_group_id = aws_security_group.alb.id
+
+  type             = "egress"
+  from_port        = 0
+  to_port          = 0
+  protocol         = "-1"
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+}
+
+resource "aws_security_group_rule" "ingress_80" {
+  description       = local.security_group_rule_description
+  security_group_id = aws_security_group.alb.id
+
+  type             = "ingress"
+  from_port        = 80
+  to_port          = 80
+  protocol         = "tcp"
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+}
+
+resource "aws_security_group_rule" "ingress_443" {
+  description       = local.security_group_rule_description
+  security_group_id = aws_security_group.alb.id
+
+  type             = "ingress"
+  from_port        = 443
+  to_port          = 443
+  protocol         = "tcp"
+  cidr_blocks      = ["0.0.0.0/0"]
+  ipv6_cidr_blocks = ["::/0"]
+}

--- a/modules/terraform-aws-alb-v2/variables.tf
+++ b/modules/terraform-aws-alb-v2/variables.tf
@@ -1,0 +1,48 @@
+variable "cert_domain_name" {
+  description = "Domain name for the ACM cert attached to the ALB. This can be a wildcard. If it does not end with a `.`, var.route53_domain_name will be appended to it."
+  type        = string
+}
+
+variable "cert_sans" {
+  description = "List of subject alternative names for the ACM cert attached to the ALB. These can be wildcards. If any entry does not end with a `.`, var.route53_domain_name will be appended to it."
+  type        = list(string)
+  default     = []
+}
+
+variable "create_dns_records" {
+  description = "Determines whether or not to create Route53 records in the specified zone for the cert domain name, and all SANs. Wildcard DNS records can be created."
+  type        = bool
+  default     = true
+}
+
+variable "internal" {
+  description = "Determines whether or not the ALB is internal or public."
+  type        = bool
+  default     = false
+}
+
+variable "name" {
+  description = "The name of the ALB to create"
+  type        = string
+}
+
+variable "route53_domain_name" {
+  description = "The domain name for the Route53 hosted zone in which to create create ACM DNS validation records."
+  type        = string
+}
+
+variable "route53_private_zone" {
+  description = "Specify if the Route53 hosted zone is a private zone or not."
+  type        = bool
+  default     = false
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs to deploy the ALB to."
+  type        = list(string)
+}
+
+variable "vpc_id" {
+  description = "The VPC to create the ALB's security group in. This should be the same VPC the subnets are in."
+  type        = string
+}

--- a/modules/terraform-aws-alb-v2/versions.tf
+++ b/modules/terraform-aws-alb-v2/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.61"
+    }
+  }
+}

--- a/modules/terraform-aws-ecs-service/ecs.tf
+++ b/modules/terraform-aws-ecs-service/ecs.tf
@@ -1,0 +1,106 @@
+resource "aws_ecs_service" "this" {
+  cluster                            = var.ecs_cluster.arn
+  deployment_maximum_percent         = var.ecs_svc_deployment_max_percent
+  deployment_minimum_healthy_percent = var.ecs_svc_deployment_min_healthy_percent
+  desired_count                      = var.ecs_svc_desired_count
+  enable_ecs_managed_tags            = var.ecs_svc_enable_ecs_managed_tags
+  enable_execute_command             = var.ecs_svc_enable_execute_command
+  force_new_deployment               = var.ecs_svc_force_new_deployment
+  health_check_grace_period_seconds  = var.ecs_svc_health_check_grace_period
+  launch_type                        = var.ecs_svc_launch_type
+  name                               = local.name
+  platform_version                   = var.ecs_svc_platform_version
+  propagate_tags                     = var.ecs_svc_propagate_tags
+  scheduling_strategy                = var.ecs_svc_scheduling_strategy
+  tags                               = local.tags
+  task_definition                    = aws_ecs_task_definition.this.arn
+  triggers                           = null
+  wait_for_steady_state              = var.ecs_svc_wait_for_steady_state
+
+  # alarms - This will require configuration options to pass in alarm names, or create the alarms themselves.
+
+  dynamic "deployment_circuit_breaker" {
+    for_each = var.ecs_svc_deployment_circuit_breaker != null ? [var.ecs_svc_deployment_circuit_breaker] : []
+
+    content {
+      enable   = deployment_circuit_breaker.value.enable
+      rollback = deployment_circuit_breaker.value.rollback
+    }
+  }
+
+  dynamic "load_balancer" {
+    for_each = local.ecs_task_container_ingress
+
+    content {
+      container_name   = load_balancer.value.container.name
+      target_group_arn = aws_lb_target_group.ecs_ingress[load_balancer.key].arn
+      container_port   = load_balancer.value.container.port
+    }
+  }
+
+  network_configuration {
+    subnets          = var.ecs_svc_subnet_ids
+    security_groups  = local.ecs_svc_sg_ids
+    assign_public_ip = var.ecs_svc_assign_public_ip
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+
+    precondition {
+      condition     = var.ecs_svc_scheduling_strategy == "DAEMON" ? (var.ecs_svc_launch_type == "EC2") : true
+      error_message = "When using DAEMON scheduling strategy, var.ecs_svc_launch_type must also be EC2."
+    }
+
+    precondition {
+      condition     = var.ecs_svc_scheduling_strategy == "DAEMON" ? (var.ecs_svc_desired_count == null) : true
+      error_message = "When using DAEMON scheduling strategy, var.ecs_svc_desired_count must not be set."
+    }
+
+    precondition {
+      condition     = var.ecs_svc_scheduling_strategy == "DAEMON" ? (var.ecs_svc_deployment_max_percent == null) : true
+      error_message = "When using DAEMON scheduling strategy, var.ecs_svc_deployment_max_percent must not be set."
+    }
+
+    precondition {
+      condition     = var.ecs_svc_scheduling_strategy == "DAEMON" ? (var.ecs_svc_deployment_min_healthy_percent == null) : true
+      error_message = "When using DAEMON scheduling strategy, var.ecs_svc_deployment_min_healthy_percent must not be set."
+    }
+
+    precondition {
+      condition     = var.ecs_svc_health_check_grace_period != null ? (length(var.ecs_task_container_ingress) != 0) : true
+      error_message = "Variable ecs_svc_health_check_grace_period can only be set when service is configured to use a load balancer."
+    }
+
+    precondition {
+      condition     = var.ecs_svc_platform_version != null ? (var.ecs_svc_launch_type == "FARGATE") : true
+      error_message = "Variable ecs_svc_platform_version can only be set when service is configured to use Fargate."
+    }
+  }
+}
+
+resource "aws_ecs_task_definition" "this" {
+  container_definitions    = local.ecs_task_container_definitions
+  cpu                      = var.ecs_task_resources.cpu
+  execution_role_arn       = aws_iam_role.ecs_executor.arn
+  family                   = local.name
+  memory                   = var.ecs_task_resources.memory
+  network_mode             = "awsvpc"
+  requires_compatibilities = local.ecs_task_requires_compatibilities
+  skip_destroy             = var.ecs_task_skip_destroy
+  tags                     = local.tags
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_cloudwatch_log_group" "ecs_task" {
+  count = var.ecs_task_create_log_group ? 1 : 0
+
+  # Name should turn out to `ecs/env/project/service`
+  name              = "ecs/${join("/", split("-", local.name))}"
+  retention_in_days = var.ecs_task_log_group_retention
+  tags              = local.tags
+}

--- a/modules/terraform-aws-ecs-service/iam.tf
+++ b/modules/terraform-aws-ecs-service/iam.tf
@@ -1,0 +1,78 @@
+# Execution Role
+resource "aws_iam_role" "ecs_executor" {
+  name               = "ECS.executor.${data.aws_region.current.name}.${local.name}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_executor_arp.json
+}
+
+data "aws_iam_policy_document" "ecs_executor_arp" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_executor_managed_policy" {
+  role       = aws_iam_role.ecs_executor.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "ecs_executor_secret_access" {
+  count = length(local.ecs_task_secrets) > 0 ? 1 : 0
+
+  name   = "ecs-executor-permissions"
+  policy = data.aws_iam_policy_document.ecs_executor_secret_access[0].json
+  role   = aws_iam_role.ecs_executor.name
+}
+
+# Secrets for ECS tasks can be either SSM Parameters or Secrets
+# Instead of doing some sorcery to figure out which they are, grant access to both resource types
+data "aws_iam_policy_document" "ecs_executor_secret_access" {
+  count = length(local.ecs_task_secrets) > 0 ? 1 : 0
+
+  statement {
+    sid    = "AllowReadAccessToSecrets"
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "ssm:GetParameters",
+    ]
+
+    resources = local.ecs_task_secrets
+  }
+}
+
+# Task Role
+resource "aws_iam_role" "ecs_task" {
+  name               = "ECS.task.${data.aws_region.current.name}.${local.name}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_arp.json
+}
+
+data "aws_iam_policy_document" "ecs_task_arp" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_task_permissions" {
+  count = var.ecs_task_permissions != null ? 1 : 0
+
+  name   = "ecs-task-permissions"
+  policy = var.ecs_task_permissions
+  role   = aws_iam_role.ecs_task.name
+}

--- a/modules/terraform-aws-ecs-service/ingress.tf
+++ b/modules/terraform-aws-ecs-service/ingress.tf
@@ -1,0 +1,118 @@
+resource "aws_lb_target_group" "ecs_ingress" {
+  for_each = local.ecs_task_container_ingress
+
+  name        = each.key
+  port        = each.value.container.port
+  protocol    = each.value.container.protocol
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+
+  dynamic "health_check" {
+    for_each = can(each.value.health_check) ? [each.value.health_check] : []
+
+    content {
+      enabled = health_check.value.enabled
+      path    = health_check.value.path
+      port    = health_check.value.port
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "ecs_ingress" {
+  for_each = local.ecs_task_container_ingress
+
+  listener_arn = each.value.alb_listener_arn
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.ecs_ingress[each.key].arn
+  }
+
+  dynamic "condition" {
+    for_each = length(each.value.paths) > 0 ? { paths = each.value.paths } : {}
+
+    content {
+      path_pattern {
+        values = condition.value
+      }
+    }
+  }
+
+  dynamic "condition" {
+    for_each = length(each.value.hosts) > 0 ? { hosts = each.value.hosts } : {}
+
+    content {
+      host_header {
+        values = condition.value
+      }
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = length(each.value.paths) > 0 || length(each.value.hosts) > 0
+      error_message = "One of hosts or paths must be set for each ingress"
+    }
+  }
+}
+
+resource "aws_security_group" "ecs_sg" {
+  count = var.ecs_svc_create_security_group ? 1 : 0
+
+  description = "Security group for ECS task ${local.name}"
+  name        = "ECS.task.${local.name}"
+  tags        = local.tags
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "ecs_svc_egress" {
+  count = var.ecs_svc_create_security_group ? 1 : 0
+
+  description       = "All outbound"
+  security_group_id = aws_security_group.ecs_sg[0].id
+
+  type        = "egress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "ecs_svc_ingress_from_alb" {
+  for_each = var.ecs_svc_create_security_group ? toset(local.ecs_svc_ingress_ports) : []
+
+  description       = "This rule is managed by Terraform, do not change manually."
+  security_group_id = aws_security_group.ecs_sg[0].id
+
+  type                     = "ingress"
+  from_port                = split(":", each.value)[1]
+  to_port                  = split(":", each.value)[1]
+  protocol                 = "tcp"
+  source_security_group_id = split(":", each.value)[0]
+}
+
+data "aws_lb_listener" "selected" {
+  for_each = var.route53_zone_id != null ? toset(distinct(values(local.ecs_task_route53_records))) : []
+
+  arn = each.key
+}
+
+data "aws_lb" "selected" {
+  for_each = var.route53_zone_id != null ? toset(distinct(values(local.ecs_task_route53_records))) : []
+
+  arn = data.aws_lb_listener.selected[each.key].load_balancer_arn
+}
+
+resource "aws_route53_record" "host" {
+  for_each = var.route53_zone_id != null ? local.ecs_task_route53_records : {}
+
+  zone_id = var.route53_zone_id
+  name    = each.key
+  type    = "A"
+
+  alias {
+    name                   = data.aws_lb.selected[each.value].dns_name
+    zone_id                = data.aws_lb.selected[each.value].zone_id
+    evaluate_target_health = true
+  }
+}

--- a/modules/terraform-aws-ecs-service/locals.tf
+++ b/modules/terraform-aws-ecs-service/locals.tf
@@ -1,0 +1,58 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  /*
+  Create a list of ports to allow ingress from various security groups
+  The format of the list will be "<securit_group_id>:<port>"
+  This will allow us to use the `distinct()` function to remove duplicates
+  in case the container port and health check port are the same.
+  */
+  ecs_svc_ingress_ports = distinct(compact(flatten([
+    [for i in var.ecs_task_container_ingress : format("%s:%d", i.alb_security_group_id, i.container.port)],
+    [for i in var.ecs_task_container_ingress : format("%s:%d", i.alb_security_group_id, i.health_check.port) if can(i.health_check)],
+  ])))
+
+  ecs_svc_sg_ids = distinct(compact(flatten([
+    var.ecs_svc_security_group_ids,
+    var.ecs_svc_create_security_group ? [aws_security_group.ecs_sg[0].id] : [],
+  ])))
+
+  # Log configuration is managed by this module, so we merge it into the task container definitions
+  ecs_task_container_definitions = jsonencode([for cd in var.ecs_task_container_definitions : merge(cd, local.log_configuration)])
+
+  # Munge the ecs_task_container_ingress variable to make it a map of container name => ingress, used to index the ingress rules by name rather than position
+  ecs_task_container_ingress = { for ingress in var.ecs_task_container_ingress : (ingress.container.name) => ingress }
+
+  ecs_task_route53_records = merge([for ingress in var.ecs_task_container_ingress : { for host in ingress.hosts : (host) => ingress.alb_listener_arn }]...)
+
+  ecs_task_requires_compatibilities = var.ecs_task_requires_compatibilities != null ? var.ecs_task_requires_compatibilities : (
+    var.ecs_svc_launch_type != "EXTERNAL" ? [var.ecs_svc_launch_type] : null
+  )
+
+  # Get a list of ECS task secrets to grant permission for the ECS task executor to fetch them
+  ecs_task_secrets = distinct(compact(flatten([for cd in var.ecs_task_container_definitions : [for s in cd.secrets != null ? cd.secrets : [] : s.valueFrom]])))
+
+  log_configuration = var.ecs_task_create_log_group ? {
+    logConfiguration = {
+      logDriver = "awslogs"
+
+      options = {
+        awslogs-region        = data.aws_region.current.name
+        awslogs-group         = aws_cloudwatch_log_group.ecs_task[0].name
+        awslogs-stream-prefix = "ecs"
+      }
+    }
+  } : {}
+
+  # If var.project and var.service name are the same, omit var.service to avoid redundancy in the name
+  name = join("-", distinct([var.environment, var.project, var.service]))
+
+  tags = merge({
+    environment = var.environment
+    project     = var.project
+    region      = data.aws_region.current.name
+    service     = var.service
+  }, var.tags)
+}

--- a/modules/terraform-aws-ecs-service/variables.tf
+++ b/modules/terraform-aws-ecs-service/variables.tf
@@ -1,0 +1,282 @@
+variable "ecs_cluster" {
+  description = "ECS cluster object for this task. (Pass in the ecs_cluster Terraform resource.)"
+
+  type = object({
+    arn  = string
+    name = string
+  })
+}
+
+variable "ecs_svc_assign_public_ip" {
+  description = "Determines whether or not to assign public IPs to the ECS tasks created by the ECS service. Only set to true if running in a public subnet."
+  type        = bool
+  default     = false
+}
+
+variable "ecs_svc_create_security_group" {
+  description = "Determines whether or not to create a security group, allowing ingress from the specified ALB to the ECS service."
+  type        = bool
+  default     = true
+}
+
+variable "ecs_svc_deployment_circuit_breaker" {
+  description = "Configuration block for deployment circuit breaker. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-circuit-breaker.html for more info."
+
+  type = object({
+    enable   = bool
+    rollback = bool
+  })
+
+  default = null
+}
+
+variable "ecs_svc_deployment_max_percent" {
+  description = "Upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment. Not valid when using the DAEMON scheduling strategy."
+  type        = number
+  default     = null
+}
+
+variable "ecs_svc_deployment_min_healthy_percent" {
+  description = "Lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment."
+  type        = number
+  default     = null
+}
+
+variable "ecs_svc_desired_count" {
+  description = "Number of instances of the task definition to place and keep running."
+  type        = number
+  default     = null
+}
+
+variable "ecs_svc_enable_ecs_managed_tags" {
+  description = "Specifies whether to enable Amazon ECS managed tags for the tasks within the service. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-using-tags.html#managed-tags for more info."
+  type        = bool
+  default     = true
+}
+
+variable "ecs_svc_enable_execute_command" {
+  description = "Specifies whether to enable Amazon ECS Exec for the tasks within the service. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html for more info."
+  type        = bool
+  default     = false
+}
+
+variable "ecs_svc_force_new_deployment" {
+  description = "Enable to force a new task deployment of the service."
+  type        = bool
+  default     = false
+}
+
+variable "ecs_svc_health_check_grace_period" {
+  description = "Seconds to ignore failing load balancer health checks on newly instantiated tasks"
+  type        = number
+  default     = null
+
+  validation {
+    condition = var.ecs_svc_health_check_grace_period == null ? true : (
+      (var.ecs_svc_health_check_grace_period > 0) && (var.ecs_svc_health_check_grace_period <= 2147483647)
+    )
+
+    error_message = "Variable ecs_svc_health_check_grace_period must be betweek 1 and 2147483647 inclusive, or null."
+  }
+}
+
+variable "ecs_svc_launch_type" {
+  description = "Launch type on which to run your service."
+  type        = string
+  default     = "FARGATE"
+
+  validation {
+    condition     = contains(["EC2", "FARGATE", "EXTERNAL"], var.ecs_svc_launch_type)
+    error_message = "Variable ecs_svc_launch_type must be one of: EC2, FARGATE, or EXTERNAL."
+  }
+}
+
+variable "ecs_svc_platform_version" {
+  description = "Platform version on which to run your service. See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html for more info."
+  type        = string
+  default     = "1.4.0"
+}
+
+variable "ecs_svc_propagate_tags" {
+  description = "Specifies whether to propagate the tags from the task definition or the service to the tasks."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.ecs_svc_propagate_tags == null ? true : contains(["SERVICE", "TASK_DEFINITION"], var.ecs_svc_propagate_tags)
+    error_message = "Variable ecs_svc_propagate_tags must be one of: SERVICE, or TASK_DEFINITION."
+  }
+}
+
+variable "ecs_svc_scheduling_strategy" {
+  description = "Scheduling strategy to use for the service."
+  type        = string
+  default     = "REPLICA"
+
+  validation {
+    condition     = contains(["REPLICA", "DAEMON"], var.ecs_svc_scheduling_strategy)
+    error_message = "Variable ecs_svc_scheduling_strategy must be one of: REPLICA, or DAEMON."
+  }
+}
+
+variable "ecs_svc_security_group_ids" {
+  description = "List of additional security group IDs to attach to the ECS service."
+  type        = list(string)
+  default     = []
+}
+
+variable "ecs_svc_subnet_ids" {
+  description = "Subnet IDs to associate the ECS service with."
+  type        = list(string)
+}
+
+variable "ecs_svc_wait_for_steady_state" {
+  description = "If true, Terraform will wait for the service to reach a steady state (like aws ecs wait services-stable) before continuing."
+  type        = bool
+  default     = false
+}
+
+variable "ecs_task_container_definitions" {
+  description = "ECS task container definitions."
+
+  type = list(object({
+    name  = string
+    image = string
+
+    portMappings = optional(list(object({
+      containerPort = number
+      protocol      = optional(string)
+    })))
+
+    entryPoint = optional(list(string))
+    command    = optional(list(string))
+
+    environment = optional(list(object({
+      name  = string
+      value = string
+    })))
+
+    secrets = optional(list(object({
+      name      = string
+      valueFrom = string
+    })))
+
+    healthCheck = optional(object({
+      command     = list(string)
+      interval    = optional(number)
+      timeout     = optional(number)
+      retries     = optional(number)
+      startPeriod = optional(number)
+    }))
+  }))
+}
+
+variable "ecs_task_container_ingress" {
+  description = "Ingress attributes for ESC task containers."
+
+  type = list(object({
+    alb_listener_arn      = string
+    alb_security_group_id = string
+
+    container = object({
+      name     = string
+      port     = number
+      protocol = optional(string, "HTTP")
+    })
+
+    health_check = optional(object({
+      enabled = bool
+      path    = string
+      port    = number
+    }))
+
+    hosts = optional(list(string), [])
+    paths = optional(list(string), [])
+  }))
+
+  default = []
+}
+
+variable "ecs_task_create_log_group" {
+  description = "Specifies whether or not to create a log group in Cloudwatch for the ECS task."
+  type        = bool
+  default     = true
+}
+
+variable "ecs_task_log_group_retention" {
+  description = "Specifies the number of days you want to retain log events in the specified log group."
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = contains([0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653], var.ecs_task_log_group_retention)
+    error_message = "Variable cw_log_group_retention must be one of [0, 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653]."
+  }
+}
+
+variable "ecs_task_permissions" {
+  description = "IAM policy document granting necessary permissions to the ECS task. (Use data.iam_policy_document.foo.json as the value for this variable.)"
+  type        = string
+  default     = null
+}
+
+variable "ecs_task_resources" {
+  description = "Compute resources for the ECS task."
+
+  type = object({
+    cpu    = number
+    memory = number
+  })
+}
+
+variable "ecs_task_requires_compatibilities" {
+  description = "Set of launch types required by the task."
+  type        = list(string)
+  default     = null
+
+  validation {
+    condition = var.ecs_task_requires_compatibilities == null ? true : alltrue(
+      [for c in var.ecs_task_requires_compatibilities : contains(["EC2", "FARGATE"], c)]
+    )
+
+    error_message = "Valid values for ecs_task_requires_compatibilities are EC2 and FARGATE."
+  }
+}
+
+variable "ecs_task_skip_destroy" {
+  description = "Whether to retain the old revision when the resource is destroyed or replacement is necessary."
+  type        = bool
+  default     = false
+}
+
+variable "environment" {
+  description = "The environment in which the service runs in."
+  type        = string
+}
+
+variable "project" {
+  description = "The project that the service belongs to. (ex: name-generator, helloworld)"
+  type        = string
+}
+
+variable "route53_zone_id" {
+  description = "The Route53 Zone ID to create DNS records in."
+  type        = string
+  default     = null
+}
+
+variable "service" {
+  description = "The specific service in the project. (ex: api-v1, greeter)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources managed by this module."
+  type        = map(string)
+  default     = {}
+}
+
+variable "vpc_id" {
+  description = "The VPC in which to create the ECS related resources."
+  type        = string
+}

--- a/modules/terraform-aws-ecs-service/versions.tf
+++ b/modules/terraform-aws-ecs-service/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.61"
+    }
+  }
+}

--- a/modules/terraform-aws-helloworld/ecr.tf
+++ b/modules/terraform-aws-helloworld/ecr.tf
@@ -1,0 +1,27 @@
+module "ecr" {
+  source  = "terraform-aws-modules/ecr/aws"
+  version = "1.6.0"
+
+  repository_name = local.ecr_repository_name
+
+  repository_read_write_access_arns = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+
+  repository_lifecycle_policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1,
+        description  = "Keep last ${var.ecr_images_to_keep} images",
+
+        selection = {
+          tagStatus   = "any",
+          countType   = "imageCountMoreThan",
+          countNumber = var.ecr_images_to_keep
+        },
+
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/modules/terraform-aws-helloworld/ecs-service.tf
+++ b/modules/terraform-aws-helloworld/ecs-service.tf
@@ -1,0 +1,76 @@
+module "this" {
+  source = "../terraform-aws-ecs-service"
+  count  = var.deploy ? 1 : 0
+
+  environment = var.environment
+  project     = local.project
+  service     = local.service
+
+  ecs_cluster           = local.ecs
+  ecs_svc_desired_count = var.replicas
+  ecs_svc_subnet_ids    = local.vpc.private_subnets
+  vpc_id                = local.vpc.id
+  route53_zone_id       = var.route53_zone_id
+
+  ecs_task_log_group_retention      = 1
+  ecs_task_requires_compatibilities = ["FARGATE"]
+
+  # ecs_task_permissions = "data.aws_iam_policy_document.permissions.json"
+
+  ecs_task_container_definitions = [{
+    name  = local.ecr_repository_name
+    image = format("%s:%s", module.ecr.repository_url, var.image_tag)
+
+    portMappings = [{
+      containerPort = var.container_port
+    }]
+
+    environment = [
+      {
+        name  = "PORT"
+        value = tostring(var.container_port)
+      },
+      {
+        name  = "spring_profiles_active",
+        value = local.profile
+      },
+      {
+        name  = "BAR",
+        value = "foo"
+      },
+    ]
+
+    # secrets = [
+    #   {
+    #     name      = "mysql.user",
+    #     valueFrom = "TODO: AWS SSM SECRET"
+    #   },
+    #   {
+    #     name      = "mysql.pass",
+    #     valueFrom = "TODO: AWS SSM SECRET"
+    #   },
+    # ]
+  }]
+
+  ecs_task_container_ingress = [{
+    alb_listener_arn      = local.alb.listener_arn
+    alb_security_group_id = local.alb.sg_id
+    hosts                 = var.hosts
+
+    container = {
+      name = local.ecr_repository_name
+      port = var.container_port
+    }
+
+    health_check = {
+      enabled = true
+      path    = "/actuator/health"
+      port    = var.container_port
+    }
+  }]
+
+  ecs_task_resources = {
+    cpu    = var.resources.cpu
+    memory = var.resources.memory
+  }
+}

--- a/modules/terraform-aws-helloworld/locals.tf
+++ b/modules/terraform-aws-helloworld/locals.tf
@@ -1,0 +1,19 @@
+data "aws_caller_identity" "current" {}
+
+module "shared_infra_data" {
+  source = "../terraform-aws-shared-infra/modules/data"
+
+  environment = var.environment
+}
+
+locals {
+  alb = module.shared_infra_data.alb
+  ecs = module.shared_infra_data.ecs
+  vpc = module.shared_infra_data.vpc
+
+  profile = var.profile != null ? var.profile : var.environment
+  project = "helloworld"
+  service = "api-v1"
+
+  ecr_repository_name = format("%s-%s", local.project, local.service)
+}

--- a/modules/terraform-aws-helloworld/variables.tf
+++ b/modules/terraform-aws-helloworld/variables.tf
@@ -1,0 +1,49 @@
+variable "container_port" {
+  default = 8080
+}
+
+variable "image_tag" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "hosts" {
+  type = list(string)
+}
+
+variable "resources" {
+  type = object({
+    cpu    = optional(number, 256)
+    memory = optional(number, 512)
+  })
+
+  default = {
+    cpu    = 256
+    memory = 512
+  }
+}
+
+variable "profile" {
+  type    = string
+  default = null
+}
+
+variable "deploy" {
+  default = false
+}
+
+variable "ecr_images_to_keep" {
+  default = 10
+}
+
+variable "route53_zone_id" {
+  type    = string
+  default = null
+}
+
+variable "replicas" {
+  default = 1
+}

--- a/modules/terraform-aws-helloworld/versions.tf
+++ b/modules/terraform-aws-helloworld/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.61"
+    }
+  }
+}

--- a/modules/terraform-aws-shared-infra/locals.tf
+++ b/modules/terraform-aws-shared-infra/locals.tf
@@ -1,0 +1,19 @@
+locals {
+  output_alb = var.create_alb ? {
+    arn          = module.alb[0].arn
+    sg_id        = module.alb[0].security_group.id
+    listener_arn = module.alb[0].listener.arn
+  } : {}
+
+  output_ecs = {
+    arn  = module.ecs.cluster_arn
+    id   = module.ecs.cluster_id
+    name = module.ecs.cluster_name
+  }
+
+  output_vpc = {
+    id              = module.vpc.vpc_id
+    private_subnets = module.vpc.private_subnets
+    public_subnets  = module.vpc.public_subnets
+  }
+}

--- a/modules/terraform-aws-shared-infra/main.tf
+++ b/modules/terraform-aws-shared-infra/main.tf
@@ -1,0 +1,40 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "4.0.1"
+
+  name = "${var.environment}-ecs"
+  cidr = var.vpc_cidr
+
+  azs              = var.vpc_azs
+  private_subnets  = var.vpc_private_subnets
+  public_subnets   = var.vpc_public_subnets
+  database_subnets = var.vpc_database_subnets
+
+  create_database_subnet_group = var.vpc_database_subnets != null
+
+  enable_nat_gateway     = var.vpc_enable_nat_gateway
+  single_nat_gateway     = var.vpc_single_nat_gateway
+  one_nat_gateway_per_az = var.vpc_enable_nat_gateway ? !var.vpc_single_nat_gateway : false
+}
+
+module "ecs" {
+  source  = "terraform-aws-modules/ecs/aws"
+  version = "4.1.3"
+
+  cluster_name = "${var.environment}-ecs-fargate"
+}
+
+module "alb" {
+  source = "../terraform-aws-alb-v2"
+
+  count = var.create_alb ? 1 : 0
+
+  cert_domain_name     = var.alb_cert_domain_name
+  cert_sans            = var.alb_cert_sans
+  create_dns_records   = var.alb_create_dns_records
+  name                 = "${module.ecs.cluster_name}-ingress"
+  route53_domain_name  = var.route53_domain_name
+  route53_private_zone = var.route53_private_zone
+  subnet_ids           = module.vpc.public_subnets
+  vpc_id               = module.vpc.vpc_id
+}

--- a/modules/terraform-aws-shared-infra/modules/data/main.tf
+++ b/modules/terraform-aws-shared-infra/modules/data/main.tf
@@ -1,0 +1,11 @@
+data "aws_ssm_parameter" "alb" {
+  name = "/infrastructure/${var.environment}/shared/alb"
+}
+
+data "aws_ssm_parameter" "ecs" {
+  name = "/infrastructure/${var.environment}/shared/ecs"
+}
+
+data "aws_ssm_parameter" "vpc" {
+  name = "/infrastructure/${var.environment}/shared/vpc"
+}

--- a/modules/terraform-aws-shared-infra/modules/data/outputs.tf
+++ b/modules/terraform-aws-shared-infra/modules/data/outputs.tf
@@ -1,0 +1,11 @@
+output "alb" {
+  value = nonsensitive(jsondecode(base64decode(data.aws_ssm_parameter.alb.value)))
+}
+
+output "ecs" {
+  value = nonsensitive(jsondecode(base64decode(data.aws_ssm_parameter.ecs.value)))
+}
+
+output "vpc" {
+  value = nonsensitive(jsondecode(base64decode(data.aws_ssm_parameter.vpc.value)))
+}

--- a/modules/terraform-aws-shared-infra/modules/data/variables.tf
+++ b/modules/terraform-aws-shared-infra/modules/data/variables.tf
@@ -1,0 +1,4 @@
+variable "environment" {
+  description = "The name of the environment in which to stand up all resources managed by this module."
+  type        = string
+}

--- a/modules/terraform-aws-shared-infra/modules/data/versions.tf
+++ b/modules/terraform-aws-shared-infra/modules/data/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.61"
+    }
+  }
+}

--- a/modules/terraform-aws-shared-infra/outputs.tf
+++ b/modules/terraform-aws-shared-infra/outputs.tf
@@ -1,0 +1,11 @@
+output "alb" {
+  value = local.output_alb
+}
+
+output "ecs" {
+  value = local.output_ecs
+}
+
+output "vpc" {
+  value = local.output_vpc
+}

--- a/modules/terraform-aws-shared-infra/ssm.tf
+++ b/modules/terraform-aws-shared-infra/ssm.tf
@@ -1,0 +1,23 @@
+resource "aws_ssm_parameter" "output_alb" {
+  count = var.create_outputs_as_ssm_parameters ? 1 : 0
+
+  name           = "/infrastructure/${var.environment}/shared/alb"
+  type           = "String"
+  insecure_value = base64encode(jsonencode(local.output_alb))
+}
+
+resource "aws_ssm_parameter" "output_ecs" {
+  count = var.create_outputs_as_ssm_parameters ? 1 : 0
+
+  name           = "/infrastructure/${var.environment}/shared/ecs"
+  type           = "String"
+  insecure_value = base64encode(jsonencode(local.output_ecs))
+}
+
+resource "aws_ssm_parameter" "output_vpc" {
+  count = var.create_outputs_as_ssm_parameters ? 1 : 0
+
+  name           = "/infrastructure/${var.environment}/shared/vpc"
+  type           = "String"
+  insecure_value = base64encode(jsonencode(local.output_vpc))
+}

--- a/modules/terraform-aws-shared-infra/variables.tf
+++ b/modules/terraform-aws-shared-infra/variables.tf
@@ -1,0 +1,84 @@
+variable "alb_cert_domain_name" {
+  description = "Domain name for the ACM cert attached to the ALB. This can be a wildcard. If it does not end with a `.`, var.route53_domain_name will be appended to it."
+  type        = string
+}
+
+variable "alb_cert_sans" {
+  description = "List of subject alternative names for the ACM cert attached to the ALB. These can be wildcards. If any entry does not end with a `.`, var.route53_domain_name will be appended to it."
+  type        = list(string)
+  default     = []
+}
+
+variable "alb_create_dns_records" {
+  description = "Determines whether or not to create Route53 records in the specified zone for the cert domain name, and all SANs. Wildcard DNS records can be created."
+  type        = bool
+  default     = true
+}
+
+variable "create_alb" {
+  description = "Determines whether or not to create an ALB to allow ingress to the ECS cluster."
+  type        = bool
+  default     = true
+}
+
+variable "create_outputs_as_ssm_parameters" {
+  description = "When set to `true` outputs will also be stored as SSM parameters. Use the nested module to fetch them."
+  type        = bool
+  default     = true
+}
+
+variable "environment" {
+  description = "The name of the environment in which to stand up all resources managed by this module."
+  type        = string
+}
+
+variable "route53_domain_name" {
+  description = "The domain name for the Route53 hosted zone in which to create create ACM DNS validation records."
+  type        = string
+}
+
+variable "route53_private_zone" {
+  description = "Specify if the Route53 hosted zone is a private zone or not."
+  type        = bool
+  default     = false
+}
+
+variable "vpc_azs" {
+  description = "List of availability zones to deploy VPC subnets to. Specify the full AZ name. Ex: `us-east-1a`."
+  type        = list(string)
+}
+
+variable "vpc_cidr" {
+  description = "Network CIDR for the VPC."
+  type        = string
+}
+
+variable "vpc_database_subnets" {
+  description = "List of database subnets, in CIDR format, to create for the VPC."
+  type        = list(string)
+  default     = null
+}
+
+variable "vpc_enable_nat_gateway" {
+  description = "Determines whether or not to create NAT gateway(s) for the VPC."
+  type        = bool
+  default     = true
+}
+
+variable "vpc_private_subnets" {
+  description = "List of private subnets, in CIDR format, to create for the VPC."
+  type        = list(string)
+  default     = null
+}
+
+variable "vpc_public_subnets" {
+  description = "List of public subnets, in CIDR format, to create for the VPC."
+  type        = list(string)
+  default     = null
+}
+
+variable "vpc_single_nat_gateway" {
+  description = "Set to `true` to create a single NAT gateway for the VPC."
+  type        = bool
+  default     = false
+}

--- a/modules/terraform-aws-shared-infra/versions.tf
+++ b/modules/terraform-aws-shared-infra/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.61"
+    }
+  }
+}


### PR DESCRIPTION
I have refactored the modules to better encapsulate their related resources
```
modules
├── terraform-aws-alb-v2          # This is a rewrite of the alb module
├── terraform-aws-ecs-service     # This is a "component" module to be used in service modules
├── terraform-aws-helloworld      # This is a "service" module that creates the specific resources for the "helloworld" service
└── terraform-aws-shared-infra    # This module instantiates resources such as VPC and ECS cluster
    └── modules
        └── data  # This module is coupled with the shared-infra module, it is used to make life easier when collecting information about the resources created by shared-infra
```

The `live` directory represents infrastructure deployed by Terraform
```
live
├── services         # Each service deployed should have a folder below
│   └── helloworld   # No resources are declared at this level
│       ├── dev      # This serves only to instantiate the `helloworld` module declared above, for the `dev` environment
│       │   ├── main.tf
│       │   ├── providers.tf
│       │   ├── state.tf
│       │   └── versions.tf
│       └── prod
└── shared    # Technically there is nothing differentiating the shared infra from a service infra, but we treat it as special since the service modules will depend on values created by this module
    ├── dev   # Similar to the `helloworld/dev` directory, this serves only to instantiate the `shared-infra` module declared above
    │   ├── main.tf
    │   ├── providers.tf
    │   ├── state.tf
    │   └── versions.tf
    └── prod
```

The outputs from the `shared-infra` module are stored as AWS SSM parameters so that other modules can use the `shared-infra/data` module to collect information about the VPC, ECS cluster, and ALB. If changes are made to the `shared-infra` module that change the output, a similar change should be made to the `shared-infra/data` module. These modules should respect semantic versioning, and backwards incompatible changes should be carefully considered.

A few important notes about modules:
* Component modules should only have other component modules as dependencies, the dependencies should be versioned.
* Service modules should only have other component modules as dependencies, the dependencies should be versioned.
* The shared infrastructure module(s) should only have other component modules as dependencies, the dependencies should be versioned.
* All dependencies should be versioned
* Most of the dependencies in this example are not versioned. Ideally we'd have a private Terraform registry to keep versioned TF artifacts.
* Controlling the versions is how we can effect changes to one environment but not the other.